### PR TITLE
Provide a working Dockerfile for Linux based systems

### DIFF
--- a/dockerfiles/Dockerfile.inxt-core-daemon
+++ b/dockerfiles/Dockerfile.inxt-core-daemon
@@ -1,11 +1,5 @@
 FROM debian:10
-RUN apt update && apt install -y make git gcc python3 python bash curl build-essential libssl-dev
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
+RUN apt update && apt install -y make git gcc python3 python bash curl build-essential libssl-dev nodejs npm
 ENV STORJ_NETWORK=INXT
-ENV NVM_DIR /root/.nvm
-ENV NODE_VERSION 8.15
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-ENV PATH      $NVM_DIR/versions/v$NODE_VERSION/bin:$PATH
-RUN . $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && git clone https://github.com/internxt/core-daemon && cd core-daemon && npm i && npm link
+RUN git clone https://github.com/internxt/core-daemon && cd core-daemon && npm i && npm link
 

--- a/dockerfiles/Dockerfile.inxt-core-daemon
+++ b/dockerfiles/Dockerfile.inxt-core-daemon
@@ -1,0 +1,11 @@
+FROM debian:10
+RUN apt update && apt install -y make git gcc python3 python bash curl build-essential libssl-dev
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
+ENV STORJ_NETWORK=INXT
+ENV NVM_DIR /root/.nvm
+ENV NODE_VERSION 8.15
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
+ENV PATH      $NVM_DIR/versions/v$NODE_VERSION/bin:$PATH
+RUN . $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && git clone https://github.com/internxt/core-daemon && cd core-daemon && npm i && npm link
+


### PR DESCRIPTION
The title is pretty self-explanatory. When trying to build the provided `storjshare-daemon-ubuntu.dockerfile` I get the following error:

> ## Your distribution, identified as "focal", is not currently supported, please contact NodeSource at https://github.com/nodesource/distributions/issues if you think this is incorrect or would like your distribution to be considered for support
> 
> /bin/sh: 1: npm: not found
> /bin/sh: 1: xcore: not found
> Error: error building at STEP "RUN apt-get update && apt-get -y install apt-utils curl && curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get -y install build-essential git libssl-dev nodejs python vim && npm install --global internxt/xcore-daemon --unsafe-perm && apt-get --purge remove -y apt-utils build-essential curl git libssl-dev python vim && apt autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/npm* && echo npm --version; npm --version && echo xcore --version; xcore --version": error while running runtime: exit status 127

The Dockerfile provided in this PR should work for reproducible builds. Can the new Dockerfile replace the ubuntu one or is there a reason to keep it around that I did not consider yet?